### PR TITLE
Fix duplicate isValidEmail declaration

### DIFF
--- a/script.js
+++ b/script.js
@@ -1369,12 +1369,6 @@ function showEmailCheckError(message) {
     errorDiv.style.display = 'block';
 }
 
-// Validate email format
-function isValidEmail(email) {
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    return emailRegex.test(email);
-}
-
 // Clear the registration form
 function clearForm() {
     const form = document.getElementById('registrationForm');


### PR DESCRIPTION
Remove duplicate `isValidEmail` function to fix 'Identifier has already been declared' syntax error.

---
<a href="https://cursor.com/background-agent?bcId=bc-1cdf2f7d-1135-4011-abda-7b6a6aa2e891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1cdf2f7d-1135-4011-abda-7b6a6aa2e891">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

