### PR TITLE
Hide upload fields on new registration

### DIFF
--- a/script.js
+++ b/script.js
@@ -1417,6 +1417,23 @@ function showFormForNewUser() {
         isUpdateField.value = '0';
     }
     
+    // Trigger upload field validation to keep them hidden initially for new users
+    const requiredFields = [
+        'full_name', 'email', 'phone', 'birth_date', 'gender', 'position', 
+        'education', 'experience_years', 'address', 'work_vision', 'work_mission', 'motivation'
+    ];
+    
+    // Hide upload fields initially and show warning
+    const uploadWarning = document.getElementById('upload-warning');
+    const uploadFieldsRequired = document.getElementById('upload-fields-required');
+    const uploadFieldsIdentity = document.getElementById('upload-fields-identity');
+    const uploadFieldsOptional = document.getElementById('upload-fields-optional');
+    
+    if (uploadWarning) uploadWarning.style.display = 'block';
+    if (uploadFieldsRequired) uploadFieldsRequired.style.display = 'none';
+    if (uploadFieldsIdentity) uploadFieldsIdentity.style.display = 'none';
+    if (uploadFieldsOptional) uploadFieldsOptional.style.display = 'none';
+    
     showNotification('Silakan isi formulir pendaftaran baru', 'info');
 }
 
@@ -1436,6 +1453,9 @@ function showFormForExistingUser() {
         isUpdateField.value = '1';
     }
     
+    // Show upload fields for existing users since they already have filled data
+    showUploadFields();
+    
     showNotification('Form telah diisi dengan data yang tersimpan. Anda dapat mengubah data sesuai kebutuhan.', 'success');
 }
 
@@ -1448,9 +1468,6 @@ function enableFormFields() {
             input.disabled = false;
         });
     }
-    
-    // Show upload fields
-    showUploadFields();
 }
 
 // Show upload fields


### PR DESCRIPTION
Hide upload fields for new registrations until required form fields are completed to improve user experience.

The previous implementation automatically showed upload fields for new registrations, bypassing the existing validation that requires other form fields to be filled first. This change ensures that new users are guided to complete their basic information before being prompted to upload documents, while existing users still see upload fields immediately.

---
<a href="https://cursor.com/background-agent?bcId=bc-86219d39-d934-40fb-a23e-c7dd33bd272e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86219d39-d934-40fb-a23e-c7dd33bd272e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

