### PR TITLE
Fix sql syntax error in registration

### DIFF
--- a/admin/index.php
+++ b/admin/index.php
@@ -38,7 +38,12 @@ if (!empty($searchTerm)) {
 $whereClause = !empty($whereConditions) ? 'WHERE ' . implode(' AND ', $whereConditions) : '';
 
 // Get applications with registration number based on creation date order
-$sql = "SELECT *, ROW_NUMBER() OVER (ORDER BY created_at ASC) as registration_number FROM applications $whereClause ORDER BY created_at DESC";
+$sql = "SELECT * FROM (
+            SELECT *, ROW_NUMBER() OVER (ORDER BY created_at ASC) as registration_number 
+            FROM applications
+        ) as numbered_applications 
+        $whereClause 
+        ORDER BY created_at DESC";
 $stmt = $pdo->prepare($sql);
 $stmt->execute($params);
 $applications = $stmt->fetchAll();


### PR DESCRIPTION
Fix SQL syntax error by restructuring the query to correctly apply the WHERE clause with the ROW_NUMBER() window function.

The original query incorrectly placed the `WHERE` clause within the `ROW_NUMBER() OVER()` window function's scope, causing a `SQLSTATE[42000]: Syntax error or access violation: 1064` error. This change wraps the window function in a subquery, allowing the `WHERE` clause to be applied correctly to the numbered results, resolving the syntax issue.

---
<a href="https://cursor.com/background-agent?bcId=bc-120b5b65-087e-456f-bc12-d5ee44ec23fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-120b5b65-087e-456f-bc12-d5ee44ec23fc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

