### PR TITLE
Handle existing file uploads and re-upload option

### DIFF
--- a/check_email.php
+++ b/check_email.php
@@ -86,7 +86,15 @@ try {
                 'k3_certificate' => $application['k3_certificate'],
                 'work_vision' => $application['work_vision'],
                 'work_mission' => $application['work_mission'],
-                'motivation' => $application['motivation']
+                'motivation' => $application['motivation'],
+                'files' => [
+                    'cv_file' => $application['cv_file'],
+                    'photo_file' => $application['photo_file'],
+                    'ktp_file' => $application['ktp_file'],
+                    'ijazah_file' => $application['ijazah_file'],
+                    'certificate_file' => $application['certificate_file'],
+                    'sim_file' => $application['sim_file']
+                ]
             ]
         ]);
     } else {

--- a/index.html
+++ b/index.html
@@ -284,6 +284,15 @@
                                 <div id="upload-fields-required" class="row mb-3" style="display: none;">
                                     <div class="col-md-6">
                                         <label class="form-label">CV/Resume *</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="cv-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File CV sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="cv_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input" name="cv_file" accept=".pdf,.doc,.docx" required>
                                             <div class="file-preview" style="display: none;">
@@ -305,6 +314,15 @@
                                     </div>
                                     <div class="col-md-6">
                                         <label class="form-label">Foto 3x4 *</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="photo-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File foto sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="photo_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input image-input" name="photo_file" accept=".jpg,.jpeg,.png"
                                                 required>
@@ -330,6 +348,15 @@
                                 <div id="upload-fields-identity" class="row mb-3" style="display: none;">
                                     <div class="col-md-6">
                                         <label class="form-label">Foto KTP *</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="ktp-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File KTP sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="ktp_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input image-input" name="ktp_file" accept=".jpg,.jpeg,.png,.pdf" required>
                                             <div class="file-preview" style="display: none;">
@@ -351,6 +378,15 @@
                                     </div>
                                     <div class="col-md-6">
                                         <label class="form-label">Foto Ijazah *</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="ijazah-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File ijazah sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="ijazah_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input image-input" name="ijazah_file" accept=".jpg,.jpeg,.png,.pdf" required>
                                             <div class="file-preview" style="display: none;">
@@ -375,6 +411,15 @@
                                 <div id="upload-fields-optional" class="row mb-3" style="display: none;">
                                     <div class="col-md-6">
                                         <label class="form-label">Sertifikat K3 (jika ada)</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="certificate-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File sertifikat K3 sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="certificate_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input image-input" name="certificate_file"
                                                 accept=".pdf,.jpg,.jpeg,.png">
@@ -397,6 +442,15 @@
                                     </div>
                                     <div class="col-md-6">
                                         <label class="form-label">SIM A/C (jika melamar Driver)</label>
+                                        <!-- File status display for existing users -->
+                                        <div id="sim-file-status" class="existing-file-status" style="display: none;">
+                                            <div class="alert alert-success mb-2">
+                                                <i class="fas fa-check-circle"></i> File SIM sudah tersimpan: <span class="file-name"></span>
+                                                <button type="button" class="btn btn-sm btn-outline-primary ms-2 upload-ulang-btn" data-field="sim_file">
+                                                    <i class="fas fa-upload"></i> Upload Ulang
+                                                </button>
+                                            </div>
+                                        </div>
                                         <div class="upload-container">
                                             <input type="file" class="form-control file-input image-input" name="sim_file"
                                                 accept=".pdf,.jpg,.jpeg,.png">

--- a/style.css
+++ b/style.css
@@ -1095,6 +1095,55 @@ label[for="motivation"]::after {
 }
 
 /* For file inputs within upload containers */
+/* File status styles for existing users */
+.existing-file-status {
+    margin-bottom: 10px;
+}
+
+.existing-file-status .alert {
+    padding: 8px 12px;
+    margin-bottom: 0;
+    border-radius: 6px;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+}
+
+.existing-file-status .file-name {
+    font-weight: 500;
+    font-family: monospace;
+    background-color: rgba(255, 255, 255, 0.2);
+    padding: 2px 6px;
+    border-radius: 3px;
+    margin: 0 8px;
+}
+
+.upload-ulang-btn {
+    white-space: nowrap;
+    font-size: 0.875rem;
+    padding: 4px 8px;
+    transition: all 0.2s ease;
+}
+
+.upload-ulang-btn:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+}
+
+.upload-ulang-btn i {
+    margin-right: 4px;
+}
+
+/* Hide upload container when file exists and not in replacement mode */
+.existing-file-status.file-exists + .upload-container {
+    display: none;
+}
+
+/* Show upload container when in replacement mode */
+.existing-file-status.replacement-mode + .upload-container {
+    display: block;
+}
+
 .upload-container .field-highlight {
     border: 2px solid #ffc107 !important;
     border-radius: 6px;


### PR DESCRIPTION
Hide upload fields for registered users with existing files, displaying file status and an "Upload Ulang" button to allow selective file replacement, and adjust validation accordingly.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c33c16d-da65-4ce9-bd20-ea1681f57372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c33c16d-da65-4ce9-bd20-ea1681f57372">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

